### PR TITLE
Feature/payload weights

### DIFF
--- a/.idea/spacecraft-launch_vehicles.iml
+++ b/.idea/spacecraft-launch_vehicles.iml
@@ -97,4 +97,80 @@
     <LOAD_PATH number="0" />
     <I18N_FOLDERS number="1" string0="$MODULE_DIR$/config/locales" />
   </component>
+  <component name="RailsGeneratorsCache">
+    <option name="generators">
+      <list>
+        <option value="active_record:application_record" />
+        <option value="active_record:migration" />
+        <option value="active_record:model" />
+        <option value="active_record:multi_db" />
+        <option value="application_record" />
+        <option value="benchmark" />
+        <option value="channel" />
+        <option value="controller" />
+        <option value="generator" />
+        <option value="integration_test" />
+        <option value="job" />
+        <option value="mailbox" />
+        <option value="mailer" />
+        <option value="migration" />
+        <option value="model" />
+        <option value="resource" />
+        <option value="scaffold" />
+        <option value="scaffold_controller" />
+        <option value="system_test" />
+        <option value="task" />
+        <option value="test_unit:channel" />
+        <option value="test_unit:controller" />
+        <option value="test_unit:generator" />
+        <option value="test_unit:helper" />
+        <option value="test_unit:install" />
+        <option value="test_unit:integration" />
+        <option value="test_unit:job" />
+        <option value="test_unit:mailbox" />
+        <option value="test_unit:mailer" />
+        <option value="test_unit:model" />
+        <option value="test_unit:plugin" />
+        <option value="test_unit:scaffold" />
+        <option value="test_unit:system" />
+      </list>
+    </option>
+    <option name="myGenerators">
+      <list>
+        <option value="active_record:application_record" />
+        <option value="active_record:migration" />
+        <option value="active_record:model" />
+        <option value="active_record:multi_db" />
+        <option value="application_record" />
+        <option value="benchmark" />
+        <option value="channel" />
+        <option value="controller" />
+        <option value="generator" />
+        <option value="integration_test" />
+        <option value="job" />
+        <option value="mailbox" />
+        <option value="mailer" />
+        <option value="migration" />
+        <option value="model" />
+        <option value="resource" />
+        <option value="scaffold" />
+        <option value="scaffold_controller" />
+        <option value="system_test" />
+        <option value="task" />
+        <option value="test_unit:channel" />
+        <option value="test_unit:controller" />
+        <option value="test_unit:generator" />
+        <option value="test_unit:helper" />
+        <option value="test_unit:install" />
+        <option value="test_unit:integration" />
+        <option value="test_unit:job" />
+        <option value="test_unit:mailbox" />
+        <option value="test_unit:mailer" />
+        <option value="test_unit:model" />
+        <option value="test_unit:plugin" />
+        <option value="test_unit:scaffold" />
+        <option value="test_unit:system" />
+      </list>
+    </option>
+  </component>
 </module>

--- a/app/controllers/api/v1/launch_vehicles_controller.rb
+++ b/app/controllers/api/v1/launch_vehicles_controller.rb
@@ -46,6 +46,6 @@ class Api::V1::LaunchVehiclesController < ApplicationController
   end
 
   def launch_vehicle_params
-    params.require(:launch_vehicle).permit(:name)
+    params.require(:launch_vehicle).permit(:name, :payload_capacity)
   end
 end

--- a/app/controllers/api/v1/launch_vehicles_controller.rb
+++ b/app/controllers/api/v1/launch_vehicles_controller.rb
@@ -4,48 +4,34 @@ class Api::V1::LaunchVehiclesController < ApplicationController
   end
 
   def show
-    spacecraft = launch_vehicle.spacecraft
-    render json: { launch_vehicle: launch_vehicle, spacecraft: spacecraft }, status: :ok
+    spacecraft_lists = launch_vehicle.spacecraft_lists
+    render json: { launch_vehicle: launch_vehicle, spacecraft_lists: spacecraft_lists }, status: :ok
   end
 
   def create
-    @launch_vehicle = LaunchVehicle.new(launch_vehicle_params)
-    if @launch_vehicle.save
-      render json: @launch_vehicle
-    else
-      render error: { error: "Unable to Create launch_vehicle."}, status: 400
-    end
+    render json: { launch_vehicle: LaunchVehicle.create!(launch_vehicle_params) }
   end
 
   def update
-    if launch_vehicle
-      launch_vehicle.update(launch_vehicle_params)
-      render json: launch_vehicle, status: :ok
-    else
-      render error: { error: "Unable to Update launch_vehicle."}, status: 400
-    end
+    launch_vehicle.update!(launch_vehicle_params)
+    render json: { launch_vehicle: }
   end
 
   def destroy
-    if launch_vehicle
-      launch_vehicle.destroy
-      render json: { message: "launch_vehicle deleted Successfully"}, status: :ok
-    else
-      render error: { error: "Unable to Delete launch_vehicle."}, status: 400
-    end
+    launch_vehicle.destroy!
   end
 
   private
 
-  def launch_vehicles
-    @_launch_vehicles = LaunchVehicle.all
-  end
+    def launch_vehicles
+      @_launch_vehicles = LaunchVehicle.all
+    end
 
-  def launch_vehicle
-    @_launch_vehicle = LaunchVehicle.includes(:spacecrafts).find(params[:id])
-  end
+    def launch_vehicle
+      @_launch_vehicle = LaunchVehicle.includes(:spacecrafts).find(params[:id])
+    end
 
-  def launch_vehicle_params
-    params.require(:launch_vehicle).permit(:name, :payload_capacity)
-  end
+    def launch_vehicle_params
+      params.require(:launch_vehicle).permit(:name, :payload_capacity)
+    end
 end

--- a/app/controllers/api/v1/spacecrafts_controller.rb
+++ b/app/controllers/api/v1/spacecrafts_controller.rb
@@ -8,30 +8,16 @@ class Api::V1::SpacecraftsController < ApplicationController
   end
 
   def create
-    @spacecraft = Spacecraft.new(spacecraft_params)
-    if @spacecraft.save
-      render json: @spacecraft
-    else
-      render error: { error: "Unable to Create spacecraft."}, status: 400
-    end
+    render json: { spacecraft: Spacecraft.create!(spacecraft_params) }
   end
 
   def update
-    if spacecraft
-      spacecraft.update(spacecraft_params)
-      render json: spacecraft, status: :ok
-    else
-      render error: { error: "Unable to Update spacecraft."}, status: 400
-    end
+    spacecraft.update!(spacecraft_params)
+    render json: { spacecraft: }
   end
 
   def destroy
-    if spacecraft
-      spacecraft.destroy
-      render json: { message: "spacecraft deleted Successfully"}, status: :ok
-    else
-      render error: { error: "Unable to Delete spacecraft."}, status: 400
-    end
+    spacecraft.destroy
   end
 
   private

--- a/app/controllers/api/v1/spacecrafts_controller.rb
+++ b/app/controllers/api/v1/spacecrafts_controller.rb
@@ -45,6 +45,6 @@ class Api::V1::SpacecraftsController < ApplicationController
     end
 
     def spacecraft_params
-      params.require(:spacecraft).permit(:name, :launch_vehicle_id)
+      params.require(:spacecraft).permit(:name, :weight, :launch_vehicle_id)
     end
 end

--- a/app/models/launch_vehicle.rb
+++ b/app/models/launch_vehicle.rb
@@ -2,6 +2,7 @@ class LaunchVehicle < ApplicationRecord
   has_many :spacecrafts
 
   validates :name, presence: true
+  validates :payload_capacity, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
   def spacecraft
     spacecrafts.each do |spacecraft|

--- a/app/models/launch_vehicle.rb
+++ b/app/models/launch_vehicle.rb
@@ -4,11 +4,12 @@ class LaunchVehicle < ApplicationRecord
   validates :name, presence: true
   validates :payload_capacity, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
-  def spacecraft
+  def spacecraft_lists
     spacecrafts.each do |spacecraft|
       {
         id: spacecraft.id,
-        name: spacecraft.name
+        name: spacecraft.name,
+        weight: spacecraft.weight
       }
     end
   end

--- a/app/models/spacecraft.rb
+++ b/app/models/spacecraft.rb
@@ -10,8 +10,14 @@ class Spacecraft < ApplicationRecord
     def spacecraft_weight_sum_less_than_payload_capacity
       launch_vehicle = LaunchVehicle.find(self.launch_vehicle_id)
       payload_capacity = launch_vehicle.payload_capacity
-      unless ((launch_vehicle.spacecrafts.sum(:weight)) + self.weight) <= payload_capacity
-        errors.add(:weight_is_more_then_payload_capacity, "Sum of Weight of Spacecraft is more then the payload capacity of the Launch Vehicle")
+      if self.id.nil?
+        unless ((launch_vehicle.spacecrafts.sum(:weight)) + self.weight) <= payload_capacity
+          errors.add(:weight_is_more_then_payload_capacity, "Sum of Weight of Spacecraft is more then the payload capacity of the Launch Vehicle")
+        end
+      else
+        unless ((launch_vehicle.spacecrafts.sum(:weight) - (Spacecraft.find(self.id)).weight) + self.weight) <= payload_capacity
+          errors.add(:weight_is_more_then_payload_capacity, "Sum of Weight of Spacecraft is more then the payload capacity of the Launch Vehicle")
+        end
       end
     end
 end

--- a/app/models/spacecraft.rb
+++ b/app/models/spacecraft.rb
@@ -1,5 +1,17 @@
 class Spacecraft < ApplicationRecord
   belongs_to :launch_vehicle
 
+
   validates :name, presence: true
+  validates :weight, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  validate :spacecraft_weight_sum_less_than_payload_capacity
+
+  private
+    def spacecraft_weight_sum_less_than_payload_capacity
+      launch_vehicle = LaunchVehicle.find(self.launch_vehicle_id)
+      payload_capacity = launch_vehicle.payload_capacity
+      unless ((launch_vehicle.spacecrafts.sum(:weight)) + self.weight) <= payload_capacity
+        errors.add(:weight_is_more_then_payload_capacity, "Sum of Weight of Spacecraft is more then the payload capacity of the Launch Vehicle")
+      end
+    end
 end

--- a/db/migrate/20220524071922_add_weight_to_spacecraft.rb
+++ b/db/migrate/20220524071922_add_weight_to_spacecraft.rb
@@ -1,0 +1,5 @@
+class AddWeightToSpacecraft < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spacecrafts, :weight, :integer, default: 0
+  end
+end

--- a/db/migrate/20220524072109_add_payload_capacity_to_launch_vehicle.rb
+++ b/db/migrate/20220524072109_add_payload_capacity_to_launch_vehicle.rb
@@ -1,0 +1,5 @@
+class AddPayloadCapacityToLaunchVehicle < ActiveRecord::Migration[7.0]
+  def change
+    add_column :launch_vehicles, :payload_capacity, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_23_194504) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_24_072109) do
   create_table "launch_vehicles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "payload_capacity", default: 0
   end
 
   create_table "spacecrafts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -22,6 +23,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_23_194504) do
     t.bigint "launch_vehicle_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "weight", default: 0
     t.index ["launch_vehicle_id"], name: "index_spacecrafts_on_launch_vehicle_id"
   end
 


### PR DESCRIPTION
## Step 2 - Payload weights

1. Add fields to store
    1. Weight for spacecraft
    2. Payload capacity for launch vehicles
2. Add this validation
    1. The sum of the spacecraft weights that can be assigned to a launch vehicle should be under the payload capacity of the launch vehicle.
3. Update the API
    1. Include the extra field values in responses
    2. Include appropriate validation / error messages while trying to create / update