### PR TITLE
Feature/reusable launch vehicles

### DIFF
--- a/app/controllers/api/v1/launch_vehicles_controller.rb
+++ b/app/controllers/api/v1/launch_vehicles_controller.rb
@@ -5,7 +5,8 @@ class Api::V1::LaunchVehiclesController < ApplicationController
 
   def show
     spacecraft_lists = launch_vehicle.spacecraft_lists
-    render json: { launch_vehicle: launch_vehicle, spacecraft_lists: spacecraft_lists }, status: :ok
+    launch_lists = launch_vehicle.launch_lists
+    render json: { launch_vehicle: launch_vehicle, spacecraft_lists: spacecraft_lists, launch_lists: launch_lists }, status: :ok
   end
 
   def create
@@ -28,7 +29,7 @@ class Api::V1::LaunchVehiclesController < ApplicationController
     end
 
     def launch_vehicle
-      @_launch_vehicle = LaunchVehicle.includes(:spacecrafts).find(params[:id])
+      @_launch_vehicle = LaunchVehicle.includes([:spacecrafts, :launches]).find(params[:id])
     end
 
     def launch_vehicle_params

--- a/app/controllers/api/v1/launch_vehicles_controller.rb
+++ b/app/controllers/api/v1/launch_vehicles_controller.rb
@@ -32,6 +32,6 @@ class Api::V1::LaunchVehiclesController < ApplicationController
     end
 
     def launch_vehicle_params
-      params.require(:launch_vehicle).permit(:name, :payload_capacity)
+      params.require(:launch_vehicle).permit(:name, :payload_capacity, :reusable)
     end
 end

--- a/app/controllers/api/v1/launches_controller.rb
+++ b/app/controllers/api/v1/launches_controller.rb
@@ -1,0 +1,36 @@
+class Api::V1::LaunchesController < ApplicationController
+  def index
+    render json: launches, status: :ok
+  end
+
+  def show
+    render json: { launch: launch }, status: :ok
+  end
+
+  def create
+    render json: { launch: Launch.create!(launch_params) }
+  end
+
+  def update
+    launch.update!(launch_params)
+    render json: { launch: }
+  end
+
+  def destroy
+    launch.destroy!
+  end
+
+  private
+
+  def launches
+    @_launches = Launch.all
+  end
+
+  def launch
+    @_launch = Launch.find(params[:id])
+  end
+
+  def launch_params
+    params.require(:launch).permit(:launch_date, :launch_description, :launch_vehicle_id, :spacecraft_id)
+  end
+end

--- a/app/controllers/api/v1/spacecrafts_controller.rb
+++ b/app/controllers/api/v1/spacecrafts_controller.rb
@@ -1,12 +1,35 @@
 class Api::V1::SpacecraftsController < ApplicationController
   def index
-    render json: spacecrafts, status: :ok
+    spacecraft_details = spacecrafts.map do |spacecraft|
+      launch_date = if spacecraft.launch.present?
+         spacecraft.launch.launch_date
+      else
+        "yet to be launched"
+      end
+      {
+        name: spacecraft.name,
+        weight: spacecraft.weight,
+        launch_vehicle: spacecraft.launch_vehicle.name,
+        launch_date: launch_date
+      }
+    end
+    render json: { spacecrafts: spacecraft_details }, status: :ok
   end
 
   def show
-    render json: spacecraft, status: :ok
+    launch_date = if spacecraft.launch.present?
+                    spacecraft.launch.launch_date
+                  else
+                    "yet to be launched"
+                  end
+    spacecraft_details = {
+      name: spacecraft.name,
+      weight: spacecraft.weight,
+      launch_vehicle: spacecraft.launch_vehicle.name,
+      launch_date: launch_date
+    }
+    render json: { spacecraft: spacecraft_details }, status: :ok
   end
-
   def create
     render json: { spacecraft: Spacecraft.create!(spacecraft_params) }
   end
@@ -23,7 +46,7 @@ class Api::V1::SpacecraftsController < ApplicationController
   private
 
     def spacecrafts
-      @_spacecrafts = Spacecraft.all
+      @_spacecrafts = Spacecraft.includes([:launch_vehicle, :launch]).all
     end
 
     def spacecraft

--- a/app/controllers/launches_controller.rb
+++ b/app/controllers/launches_controller.rb
@@ -1,3 +1,0 @@
-class LaunchesController < ApplicationController
-
-end

--- a/app/controllers/launches_controller.rb
+++ b/app/controllers/launches_controller.rb
@@ -1,0 +1,3 @@
+class LaunchesController < ApplicationController
+
+end

--- a/app/models/launch.rb
+++ b/app/models/launch.rb
@@ -1,3 +1,10 @@
 class Launch < ApplicationRecord
   belongs_to :launch_vehicle
+  belongs_to :spacecraft
+
+  validates :launch_date, presence: true
+  validates :launch_description, presence: true
+  validates :launch_vehicle_id, presence: true
+  validates :spacecraft_id, presence: true
+
 end

--- a/app/models/launch.rb
+++ b/app/models/launch.rb
@@ -6,5 +6,5 @@ class Launch < ApplicationRecord
   validates :launch_description, presence: true
   validates :launch_vehicle_id, presence: true
   validates :spacecraft_id, presence: true
-
+  
 end

--- a/app/models/launch.rb
+++ b/app/models/launch.rb
@@ -1,0 +1,3 @@
+class Launch < ApplicationRecord
+  belongs_to :launch_vehicle
+end

--- a/app/models/launch.rb
+++ b/app/models/launch.rb
@@ -6,5 +6,25 @@ class Launch < ApplicationRecord
   validates :launch_description, presence: true
   validates :launch_vehicle_id, presence: true
   validates :spacecraft_id, presence: true
-  
+  validate :validate_reuablility_of_launch_vehicle
+  validate :validate_if_spacecraft_belongs_to_launch_vehicle
+
+  private
+    def validate_reuablility_of_launch_vehicle
+      unless launch_vehicle.reusable?
+        if Launch.where(launch_vehicle_id: self.launch_vehicle_id).present?
+          errors.add(:launch_vehicle_can_only_lauch_once, "Launch Vehicle can only launch once")
+        end
+      end
+    end
+
+    def validate_if_spacecraft_belongs_to_launch_vehicle
+      unless Spacecraft.find(self.spacecraft_id).launch_vehicle_id == launch_vehicle.id
+        errors.add(:spacecraft_does_not_belong_to_that_launch_vehicle, "Spacecraft doesnot belong to that launch vehicle")
+      end
+    end
+
+    def launch_vehicle
+      @_launch_vehicle = LaunchVehicle.find(self.launch_vehicle_id)
+    end
 end

--- a/app/models/launch_vehicle.rb
+++ b/app/models/launch_vehicle.rb
@@ -1,5 +1,6 @@
 class LaunchVehicle < ApplicationRecord
   has_many :spacecrafts
+  has_many :launch
 
   validates :name, presence: true
   validates :payload_capacity, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/launch_vehicle.rb
+++ b/app/models/launch_vehicle.rb
@@ -1,16 +1,27 @@
 class LaunchVehicle < ApplicationRecord
   has_many :spacecrafts
-  has_many :launch
+  has_many :launches
 
   validates :name, presence: true
   validates :payload_capacity, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
   def spacecraft_lists
-    spacecrafts.each do |spacecraft|
+    spacecrafts.map do |spacecraft|
       {
         id: spacecraft.id,
         name: spacecraft.name,
         weight: spacecraft.weight
+      }
+    end
+  end
+
+  def launch_lists
+    launches.map do |launch|
+      {
+        id: launch.id,
+        description: launch.launch_description,
+        date: launch.launch_date,
+        spacecraft: launch.spacecraft.name
       }
     end
   end

--- a/app/models/spacecraft.rb
+++ b/app/models/spacecraft.rb
@@ -1,6 +1,6 @@
 class Spacecraft < ApplicationRecord
   belongs_to :launch_vehicle
-
+  has_one :launch
 
   validates :name, presence: true
   validates :weight, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: "json" } do
     namespace :v1 do
       resources :spacecrafts, only: [:index, :show, :create, :update, :destroy]
-      resources :launch_vehicles, only: [:index, :show, :create, :update, :destroy] 
+      resources :launch_vehicles, only: [:index, :show, :create, :update, :destroy]
+      resources :lunches, only: [:index, :show, :create, :update, :destroy]
     end 
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :spacecrafts, only: [:index, :show, :create, :update, :destroy]
       resources :launch_vehicles, only: [:index, :show, :create, :update, :destroy]
-      resources :lunches, only: [:index, :show, :create, :update, :destroy]
+      resources :launches, only: [:index, :show, :create, :update, :destroy]
     end 
   end
 end

--- a/db/migrate/20220524191930_add_reusable_to_launch_vehicle.rb
+++ b/db/migrate/20220524191930_add_reusable_to_launch_vehicle.rb
@@ -1,0 +1,5 @@
+class AddReusableToLaunchVehicle < ActiveRecord::Migration[7.0]
+  def change
+    add_column :launch_vehicles, :reusable, :boolean
+  end
+end

--- a/db/migrate/20220524192408_create_launches.rb
+++ b/db/migrate/20220524192408_create_launches.rb
@@ -1,0 +1,10 @@
+class CreateLaunches < ActiveRecord::Migration[7.0]
+  def change
+    create_table :launches do |t|
+      t.date :launch_date
+      t.references :launch_vehicle, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220524192408_create_launches.rb
+++ b/db/migrate/20220524192408_create_launches.rb
@@ -2,7 +2,9 @@ class CreateLaunches < ActiveRecord::Migration[7.0]
   def change
     create_table :launches do |t|
       t.date :launch_date
+      t.date :launch_description
       t.references :launch_vehicle, null: false, foreign_key: true
+      t.references :spacecraft, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20220524204143_change_launch_description_type_to_string.rb
+++ b/db/migrate/20220524204143_change_launch_description_type_to_string.rb
@@ -1,0 +1,5 @@
+class ChangeLaunchDescriptionTypeToString < ActiveRecord::Migration[7.0]
+  def change
+    change_column :launches, :launch_description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_24_192408) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_24_204143) do
   create_table "launch_vehicles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "payload_capacity", default: 0
-    t.boolean "reusable", null: false, default: false
+    t.boolean "reusable"
   end
 
   create_table "launches", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.date "launch_date"
-    t.date "launch_description"
+    t.string "launch_description"
     t.bigint "launch_vehicle_id", null: false
     t.bigint "spacecraft_id", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_24_191930) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_24_192408) do
   create_table "launch_vehicles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "payload_capacity", default: 0
-    t.boolean "reusable"
+    t.boolean "reusable", null: false, default: false
+  end
+
+  create_table "launches", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.date "launch_date"
+    t.date "launch_description"
+    t.bigint "launch_vehicle_id", null: false
+    t.bigint "spacecraft_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["launch_vehicle_id"], name: "index_launches_on_launch_vehicle_id"
+    t.index ["spacecraft_id"], name: "index_launches_on_spacecraft_id"
   end
 
   create_table "spacecrafts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -28,5 +39,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_24_191930) do
     t.index ["launch_vehicle_id"], name: "index_spacecrafts_on_launch_vehicle_id"
   end
 
+  add_foreign_key "launches", "launch_vehicles"
+  add_foreign_key "launches", "spacecrafts"
   add_foreign_key "spacecrafts", "launch_vehicles"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_24_072109) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_24_191930) do
   create_table "launch_vehicles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "payload_capacity", default: 0
+    t.boolean "reusable"
   end
 
   create_table "spacecrafts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/controllers/launches_controller_test.rb
+++ b/test/controllers/launches_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LaunchesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/launches.yml
+++ b/test/fixtures/launches.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  launch_date: 2022-05-25
+  launch_vehicle: one
+
+two:
+  launch_date: 2022-05-25
+  launch_vehicle: two

--- a/test/models/launch_test.rb
+++ b/test/models/launch_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LaunchTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Step 3 - Reusable launch vehicles

1. Add the ability to mark launch vehicles as reusable
2. Update the DB and model associations to be able to store data about multiple launches per launcher. Track a date for the launch model.
3. Add these validations:
    1. Launch vehicles that are reusable can have multiple launches
    2. Non-reusable launch vehicles can have only one launch
4. Update the API for the added functionality, including validation errors
    1. Update the response of the GET endpoint for spacecraft to include the launch details (launch vehicle and date)
    2. For a given launch vehicle, an endpoint to retrieve a list of launches and the list of spacecraft in each launch